### PR TITLE
Update sero_run.py

### DIFF
--- a/seroba/tasks/sero_run.py
+++ b/seroba/tasks/sero_run.py
@@ -15,6 +15,6 @@ def run(options):
         options.read2,
         options.prefix,
         clean = (not options.noclean),
-        cov = options.coverage
+        cov = 20 if options.coverage is None else options.coverage
     )
     sero.run()


### PR DESCRIPTION
**cov** parameter set to 20 to match default parameter set in [_serotyping.py_](../serotyping.py) if the command line parameter is not given. Throws an error otherwise.